### PR TITLE
Update alpine to 3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as build
+FROM alpine:3.20 as build
 
 RUN apk add --no-cache gcc musl-dev linux-headers openssl-dev make git
 
@@ -11,7 +11,7 @@ RUN chown -R app redis-cluster-proxy
 USER app
 RUN cd redis-cluster-proxy && make -j4 install
 
-FROM alpine:3.11 as runtime
+FROM alpine:3.20 as runtime
 
 RUN apk add --no-cache libstdc++
 RUN apk add --no-cache strace


### PR DESCRIPTION
Alpine update to 3.20.
If you can, push docker image (with riscv64 platform) `unstable-alpine3.20` or update current `unstable` please.